### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ ssh client wrapper for automatic login.
 use `go get`
 
 ```
-go get -u github.com/yinheli/sshw/cmd/sshw
+go install github.com/yinheli/sshw/cmd/sshw@latest
 ```
 
 or download binary from [releases](//github.com/yinheli/sshw/releases).


### PR DESCRIPTION
should use go install instead now

see the error details
```
❯ go get -u github.com/yinheli/sshw/cmd/sshw
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```