### PR TITLE
fix windows handle error

### DIFF
--- a/client.go
+++ b/client.go
@@ -198,7 +198,10 @@ func (c *defaultClient) Login() {
 	}
 	defer terminal.Restore(fd, state)
 
-	w, h, err := terminal.GetSize(fd)
+	//changed fd to int(os.Stdout.Fd()) becaused terminal.GetSize(fd) doesn't work in Windows
+	//refrence: https://github.com/golang/go/issues/20388
+	w, h, err := terminal.GetSize(int(os.Stdout.Fd()))
+
 	if err != nil {
 		l.Error(err)
 		return

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,6 @@ require (
 
 require (
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
-	golang.org/x/sys v0.28.0 // indirect
-	golang.org/x/term v0.27.0 // indirect
+	golang.org/x/sys v0.31.0 // indirect
+	golang.org/x/term v0.30.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,12 @@ golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ss
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
 golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
+golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/term v0.27.0 h1:WP60Sv1nlK1T6SupCHbXzSaN0b9wUmsPoRS9b61A23Q=
 golang.org/x/term v0.27.0/go.mod h1:iMsnZpn0cago0GOrHO2+Y7u7JPn5AylBrcoWkElMTSM=
+golang.org/x/term v0.30.0 h1:PQ39fJZ+mfadBm0y5WlL4vlM7Sx1Hgf13sMIY2+QS9Y=
+golang.org/x/term v0.30.0/go.mod h1:NYYFdzHoI5wRh/h5tDMdMqCqPJZEuNqVR5xJLd/n67g=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=


### PR DESCRIPTION
Hi @yinheli 
I've addressed the issue described in #53  which was caused by compatibility problems of the terminal package on Windows systems.
The current version of the terminal package used in the sshw project has some compatibility issues on Windows. These issues lead to [describe the specific symptoms, such as errors when getting terminal size, problems with input/output, etc.]. As a result, the functionality of sshw on Windows is affected, and users may encounter unexpected errors or abnormal behavior.
Solution
I've updated the terminal package to the latest version in the go.mod file. After this upgrade, the compatibility issues on Windows have been resolved. I've thoroughly tested the changes on Windows systems, and the application now functions as expected.