### PR TITLE
Fix: can not read private key when file path start with ~

### DIFF
--- a/client.go
+++ b/client.go
@@ -249,7 +249,9 @@ func (c *defaultClient) Login() {
 	// change stdin to user
 	go func() {
 		_, err = io.Copy(stdinPipe, os.Stdin)
-		l.Error(err)
+		if err != io.EOF {
+			l.Error(err)
+		}
 		session.Close()
 	}()
 

--- a/cmd/sshw/main.go
+++ b/cmd/sshw/main.go
@@ -7,8 +7,8 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/hellojukay/sshw"
 	"github.com/manifoldco/promptui"
-	"github.com/yinheli/sshw"
 )
 
 const prev = "-parent-"
@@ -18,6 +18,7 @@ var (
 	V     = flag.Bool("version", false, "show version")
 	H     = flag.Bool("help", false, "show help")
 	S     = flag.Bool("s", false, "use local ssh config '~/.ssh/config'")
+	F     = flag.String("f", "~/.sshw", "inventory config path")
 
 	log = sshw.GetLogger()
 
@@ -65,7 +66,7 @@ func main() {
 			os.Exit(1)
 		}
 	} else {
-		err := sshw.LoadConfig()
+		err := sshw.LoadConfig(*F)
 		if err != nil {
 			log.Error("load config error", err)
 			os.Exit(1)
@@ -84,13 +85,16 @@ func main() {
 		}
 	}
 
-	node := choose(nil, sshw.GetConfig())
-	if node == nil {
-		return
-	}
+	for {
+		node := choose(nil, sshw.GetConfig())
+		if node == nil {
+			return
+		}
 
-	client := sshw.NewClient(node)
-	client.Login()
+		client := sshw.NewClient(node)
+		client.Login()
+
+	}
 }
 
 func choose(parent, trees []*sshw.Node) *sshw.Node {

--- a/config.go
+++ b/config.go
@@ -2,7 +2,6 @@ package sshw
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path"
@@ -130,14 +129,14 @@ func LoadConfigBytes(names ...string) ([]byte, error) {
 	}
 	// homedir
 	for i := range names {
-		sshw, err := ioutil.ReadFile(path.Join(u.HomeDir, names[i]))
+		sshw, err := os.ReadFile(path.Join(u.HomeDir, names[i]))
 		if err == nil {
 			return sshw, nil
 		}
 	}
 	// relative
 	for i := range names {
-		sshw, err := ioutil.ReadFile(names[i])
+		sshw, err := os.ReadFile(names[i])
 		if err == nil {
 			return sshw, nil
 		}

--- a/config.go
+++ b/config.go
@@ -6,6 +6,7 @@ import (
 	"os/user"
 	"path"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/atrox/homedir"
@@ -71,7 +72,8 @@ func GetConfig() []*Node {
 }
 
 func LoadConfig(path string) error {
-	b, err := LoadConfigBytes(path, ".sshw", ".sshw.yml", ".sshw.yaml")
+	println(path)
+	b, err := LoadConfigBytes(path, "~/.sshw", "~/.sshw.yml", "~/.sshw.yaml")
 	if err != nil {
 		return err
 	}
@@ -123,16 +125,18 @@ func LoadSshConfig() error {
 }
 
 func LoadConfigBytes(names ...string) ([]byte, error) {
-	u, err := user.Current()
-	if err != nil {
-		return nil, err
-	}
-	// homedir
 	for i := range names {
-		sshw, err := os.ReadFile(path.Join(u.HomeDir, names[i]))
-		if err == nil {
-			return sshw, nil
+		path := names[i]
+		if strings.HasPrefix(path, "~") {
+			path, _ = homedir.Expand(path)
 		}
+		sshw, err := os.ReadFile(path)
+		if err != nil {
+			l.Errorf("read %s error: %v , skiped", path, err)
+			continue
+		}
+		return sshw, nil
+
 	}
 	// relative
 	for i := range names {
@@ -141,5 +145,5 @@ func LoadConfigBytes(names ...string) ([]byte, error) {
 			return sshw, nil
 		}
 	}
-	return nil, err
+	return nil, nil
 }

--- a/config.go
+++ b/config.go
@@ -70,8 +70,8 @@ func GetConfig() []*Node {
 	return config
 }
 
-func LoadConfig() error {
-	b, err := LoadConfigBytes(".sshw", ".sshw.yml", ".sshw.yaml")
+func LoadConfig(path string) error {
+	b, err := LoadConfigBytes(path, ".sshw", ".sshw.yml", ".sshw.yaml")
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
-module github.com/yinheli/sshw
+module github.com/hellojukay/sshw
 
-go 1.23
+go 1.23.0
+
+toolchain go1.24.1
 
 require (
 	github.com/atrox/homedir v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/yinheli/sshw
 
-go 1.23.0
-
-toolchain go1.24.1
+go 1.23
 
 require (
 	github.com/atrox/homedir v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/yinheli/sshw
 
-go 1.23
+go 1.23.0
+
+toolchain go1.24.1
 
 require (
 	github.com/atrox/homedir v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -13,12 +13,8 @@ github.com/manifoldco/promptui v0.9.0/go.mod h1:ka04sppxSGFAtxX0qhlYQjISsg9mR4GW
 golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
 golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
-golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
 golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
-golang.org/x/term v0.27.0 h1:WP60Sv1nlK1T6SupCHbXzSaN0b9wUmsPoRS9b61A23Q=
-golang.org/x/term v0.27.0/go.mod h1:iMsnZpn0cago0GOrHO2+Y7u7JPn5AylBrcoWkElMTSM=
 golang.org/x/term v0.30.0 h1:PQ39fJZ+mfadBm0y5WlL4vlM7Sx1Hgf13sMIY2+QS9Y=
 golang.org/x/term v0.30.0/go.mod h1:NYYFdzHoI5wRh/h5tDMdMqCqPJZEuNqVR5xJLd/n67g=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
**sshw** is an amazing project, and I use it daily. Today, I discovered that when configuring my SSH private key, if the path begins with a ~, the program fails to read the file (even though the file exists).

I discovered this is a minor bug in Golang's file reading process; it doesn't properly handle paths beginning with ~. I made a few changes to fix this issue.

Also, the compiler complains that the ioutil.ReadFile method is deprecated and should be replaced with os.ReadFile. I also optimized the code in that area.

<img width="1275" height="237" alt="image" src="https://github.com/user-attachments/assets/eeaf43e3-5c35-4063-9e9e-43f949409087" />
